### PR TITLE
Fix MySQL event `Clean up Userstuff`

### DIFF
--- a/html/omnomirc_www/omnomirc.sql
+++ b/html/omnomirc_www/omnomirc.sql
@@ -105,8 +105,6 @@ ALTER TABLE `{db_prefix}channels` ADD UNIQUE (`chan`) COMMENT '';
 DROP EVENT IF EXISTS `Clean up Userstuff`;
 CREATE EVENT `Clean up Userstuff` ON SCHEDULE EVERY 1 DAY ON COMPLETION NOT PRESERVE ENABLE COMMENT 'Clean up the db' DO DELETE FROM {db_prefix}userstuff
 	WHERE (ignores = '' OR ignores IS NULL)
-	AND (ops = '' OR ops IS NULL)
-	AND (bans = '' OR bans IS NULL)
 	AND (kicks = '' OR kicks IS NULL)
 	AND globalOp = '0'
 	AND globalBan = '0';


### PR DESCRIPTION
In 2b5a72089e074a47a932001ce65d6f31999265d9, the columns `ops` and `bans` were removed from the table, but they should be removed from the event too.

It was causing this error in the mysql error log:

> [ERROR] [MY-010045] [Server] Event Scheduler: [root@localhost][acr_chat.Clean up Userstuff] Unknown column 'ops' in 'where clause'